### PR TITLE
fix: Update RSS feed generation to use dynamic data

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
-import { latestNews } from "@/lib/data";
+import { getPublishedPosts } from "@/lib/db";
 
 export async function GET() {
-  const items = latestNews.slice(0, 20).map(n => `
+  const posts = await getPublishedPosts();
+  const items = posts.slice(0, 20).map(p => `
     <item>
-      <title><![CDATA[${n.title}]]></title>
-      <link>https://ai-news-japan.example.com/news#${n.id}</link>
-      <pubDate>${new Date(n.date).toUTCString()}</pubDate>
-      <description><![CDATA[${n.summary}]]></description>
+      <title><![CDATA[${p.title}]]></title>
+      <link>${p.url}</link>
+      <guid>${p.url}</guid>
+      <pubDate>${p.createdAt.toUTCString()}</pubDate>
+      <description><![CDATA[${p.commentary}]]></description>
     </item>
   `).join("\n");
 


### PR DESCRIPTION
This commit resolves a build error caused by the RSS feed generator (`app/rss.xml/route.ts`) attempting to import `latestNews` from `lib/data.ts`, which was removed in a previous refactoring.

The RSS route has been updated to fetch its data from the new database module by calling `getPublishedPosts()`. The XML generation logic has also been updated to use the `PublishedPost` data structure.