### PR TITLE
fix: Replace in-memory DB with file-based persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ coverage/
 npm-debug.log*
 yarn-debug.log*
 pnpm-debug.log*
+
+# App data
+.data/


### PR DESCRIPTION
This commit resolves a deployment timeout issue by replacing the ephemeral in-memory database with a persistent, file-based storage system using JSON files.

The previous implementation lost all data on server restart, which likely caused instability and health check timeouts in the Render deployment environment. The new implementation in `lib/db.ts` reads from and writes to JSON files in the `.data/` directory, ensuring data persists across deployments.

This also includes the full implementation of the news curation feature, including the admin panel and RSS fetching script.